### PR TITLE
:sparkles: Create a parser structure

### DIFF
--- a/mypandoc.cabal
+++ b/mypandoc.cabal
@@ -13,11 +13,9 @@ author:         Axel ECKENBERG, Simon GAGNIER, Marius PAIN, Landry GIGANT
 maintainer:     axel.eckenberg@epitech.eu
 copyright:      2024 Epitech
 license:        BSD-3-Clause
-license-file:   LICENSE
 build-type:     Simple
 extra-source-files:
     README.md
-    CHANGELOG.md
 
 source-repository head
   type: git
@@ -26,6 +24,7 @@ source-repository head
 library
   exposed-modules:
       DataStruct
+      ParserData
   other-modules:
       Paths_mypandoc
   autogen-modules:

--- a/src/ParserData.hs
+++ b/src/ParserData.hs
@@ -1,0 +1,53 @@
+{-
+-- EPITECH PROJECT, 2024
+-- MyPandoc
+-- File description:
+-- ParserData
+-}
+
+module ParserData (
+        Parser(..)
+    ) where
+
+
+import Data.Char
+import Control.Applicative (Alternative(..))
+import Control.Monad
+
+
+data Parser a = Parser {
+    runParser :: String -> Maybe (a, String)
+}
+
+instance Functor Parser where
+    fmap fct parser = Parser $ \str -> case runParser parser str of
+        Just (a, str) -> Just (fct a, str)
+        Nothing -> Nothing
+
+instance Applicative Parser where
+    pure a = Parser $ \str -> Just (a, str)
+    parser1 <*> parser2 = Parser $ \str -> case runParser parser1 str of
+        Just (fct, str) -> case runParser parser2 str of
+            Just (a, str) -> Just (fct a, str)
+            Nothing -> Nothing
+        Nothing -> Nothing
+    parser1 *> parser2 = Parser $ \str -> case runParser parser1 str of
+        Just (_, str) -> runParser parser2 str
+        Nothing -> Nothing
+    parser1 <* parser2 = Parser $ \str -> case runParser parser1 str of
+        Just (a, str) -> case runParser parser2 str of
+            Just (_, str) -> Just (a, str)
+            Nothing -> Nothing
+        Nothing -> Nothing
+
+instance Alternative Parser where
+    empty = Parser $ \_ -> Nothing
+    parser1 <|> parser2 = Parser $ \str -> case runParser parser1 str of
+        Just (a, str) -> Just (a, str)
+        Nothing -> runParser parser2 str
+
+instance Monad Parser where
+    return = pure
+    parser >>= fct = Parser $ \str -> case runParser parser str of
+        Just (a, str) -> runParser (fct a) str
+        Nothing -> Nothing


### PR DESCRIPTION
I added a parser structure with multiple instances.
What's new, you can now use :
- `<$>` , `<*` , `*>` et `<*>`

![image](https://github.com/epitech-mirroring/MyPandoc/assets/114705049/46dfd697-2296-4286-9e58-8e1183a5ebe9)

- `<|>`

![image](https://github.com/epitech-mirroring/MyPandoc/assets/114705049/096118b9-242c-4a45-8a35-5433e1b64758)

- The do notation with your parsers

![image](https://github.com/epitech-mirroring/MyPandoc/assets/114705049/abbd5310-5be6-4e3d-ae83-d2852e39e97c)
