### PR TITLE
:bug: Fix indentation problem at the end of body in WriterXML.hs

### DIFF
--- a/src/XML/WriterXML.hs
+++ b/src/XML/WriterXML.hs
@@ -55,7 +55,7 @@ headerElementsToXML ((Date date):xs) = printIndented 2 ++ "<date>" ++ date ++
 
 bodyToXML :: Body -> String
 bodyToXML (Body content) = printIndented 1 ++ "<body>" ++
-    elementsToXML content 2 ++ "</body>" ++ printIndented 0
+    elementsToXML content 2 ++ printIndented 1 ++ "</body>" ++ printIndented 0
 
 elementsToXML :: [Element] -> Int -> String
 elementsToXML [] _ = ""


### PR DESCRIPTION
I fixed the missing indentation in the closing balise of body.

Issue solved :
- close #35 